### PR TITLE
Fixed error associated with long distance settings activated with gho…

### DIFF
--- a/AutoCircuit/control.lua
+++ b/AutoCircuit/control.lua
@@ -16,7 +16,12 @@ local function get_player_setting(player_index, name)
 end
 
 local function is_long_distance_pole(entity)
-   local poleproto = entity.prototype
+	local poleproto
+	if(entity.type == "entity-ghost") then
+		poleproto = entity.ghost_prototype
+	else
+		poleproto = entity.prototype
+	end	
    return (poleproto.supply_area_distance <= 2
            or poleproto.max_wire_distance >= 30)
 end


### PR DESCRIPTION
Error message

309.801 Error MainLoop.cpp:1404: Exception at tick 44585465: The mod Auto Circuit (0.1.2) caused a non-recoverable error. Please report this error to the mod author.

Error while running event AutoCircuit::on_built_entity (ID 6) __AutoCircuit__/control.lua:20: attempt to compare nil with number stack traceback:
    __AutoCircuit__/control.lua:20: in function 'is_long_distance_pole'
    __AutoCircuit__/control.lua:26: in function 'is_viable_for_connection'
    __AutoCircuit__/control.lua:78: in function <__AutoCircuit__/control.lua:72>
 309.801 Error ServerMultiplayerManager.cpp:92: MultiplayerManager failed: "The mod Auto Circuit (0.1.2) caused a non-recoverable error.
Please report this error to the mod author.

Error while running event AutoCircuit::on_built_entity (ID 6) __AutoCircuit__/control.lua:20: attempt to compare nil with number stack traceback:
    __AutoCircuit__/control.lua:20: in function 'is_long_distance_pole'
    __AutoCircuit__/control.lua:26: in function 'is_viable_for_connection'
    __AutoCircuit__/control.lua:78: in function <__AutoCircuit__/control.lua:72>"